### PR TITLE
Use pekko artefacts for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,11 +356,11 @@ lazy val pekko = project
   .settings(
     normalizedName := "korolev-pekko",
     libraryDependencies ++= Seq(
-      ("org.apache.pekko" %% "pekko-actor"          % pekkoVersion).cross(CrossVersion.for3Use2_13),
-      ("org.apache.pekko" %% "pekko-stream"         % pekkoVersion).cross(CrossVersion.for3Use2_13),
-      ("org.apache.pekko" %% "pekko-http"           % pekkoHttpVersion).cross(CrossVersion.for3Use2_13),
-      ("org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion     % Test).cross(CrossVersion.for3Use2_13),
-      ("org.apache.pekko" %% "pekko-http-testkit"   % pekkoHttpVersion % Test).cross(CrossVersion.for3Use2_13)
+      "org.apache.pekko" %% "pekko-actor"          % pekkoVersion,
+      "org.apache.pekko" %% "pekko-stream"         % pekkoVersion,
+      "org.apache.pekko" %% "pekko-http"           % pekkoHttpVersion,
+      "org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion     % Test,
+      "org.apache.pekko" %% "pekko-http-testkit"   % pekkoHttpVersion % Test
     )
   )
   .dependsOn(korolev)


### PR DESCRIPTION
korolev-pekko uses the scala 2.13 artefacts of pekko. Since pekko gets released for scala 3 as well, I hope there is no reason to still use cross versions.